### PR TITLE
Use logger instead of print

### DIFF
--- a/self-magritte/src/__init__.py
+++ b/self-magritte/src/__init__.py
@@ -1,8 +1,18 @@
+import logging
+
 from .ingesters.calories import CalorieIngest
 from .ingesters.workouts import WorkoutIngest
 from .utils.ssm_parameter_store import SSMParameterStore
 import schedule
 import time
+
+
+logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+logging.root.setLevel(logging.INFO)
 
 
 def main():


### PR DESCRIPTION
## Before this PR
Print is not ideal for logging, logger is a little bit better, we want to see when things happen.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

